### PR TITLE
os-helpers: Add debug for MACHINE_FEATURES

### DIFF
--- a/layers/meta-balena-dart-mx8m-plus/recipes-support/os-helpers/os-helpers.bbappend
+++ b/layers/meta-balena-dart-mx8m-plus/recipes-support/os-helpers/os-helpers.bbappend
@@ -1,0 +1,7 @@
+do_install:append() {
+    if ${@bb.utils.contains('MACHINE_FEATURES', 'raid', 'true', 'false', d)}; then
+        bbwarn "MACHINE_FEATURES contains raid"
+    else
+       bbwarn "MACHINE_FEATURES does not contain raid"
+    fi
+}


### PR DESCRIPTION
to see if it somehow includes raid support, because the mdadm problem is not present in local builds

Changelog-entry: os-helpers: Add debug for MACHINE_FEATURES